### PR TITLE
Fix fleeting zombie pigs

### DIFF
--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -130,7 +130,7 @@
     },
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ], { "id": "impale" } ],
-    "extend": { "flags": [ "GROUP_BASH", "PUSH_VEH", "HIT_AND_RUN" ] }
+    "extend": { "flags": [ "GROUP_BASH", "PUSH_VEH" ] }
   },
   {
     "id": "mon_zombie_pig_gas",
@@ -145,8 +145,7 @@
     "harvest": "exempt",
     "emit_fields": [ { "emit_id": "emit_tear_gas_stream", "delay": "1 s" } ],
     "death_function": { "effect": { "id": "death_tearburst", "hit_self": true }, "message": "A %s explode!", "corpse_type": "NO_CORPSE" },
-    "special_attacks": [ { "id": "impale" } ],
-    "extend": { "flags": [ "HIT_AND_RUN" ] }
+    "special_attacks": [ { "id": "impale" } ]
   },
   {
     "id": "mon_wolf_skeleton",


### PR DESCRIPTION
#### Summary
Bugfixes "skull pig (undead boar) flees when injured despite being zombie"

#### Purpose of change

Fixes #1234.
Steps to reproduce the bug:
1. Spawn skull pig/trench pig from the debug panel
2. Start attacking it

#### Describe the solution

Removed a flag `"HIT_AND_RUN"` unsuitable for these monsters (zombified pigs):
- Skull pig
- Trench pig
I considered removing the flag from `Trench pig` a reasonable decision
Fixes #56352

#### Describe alternatives you've considered

I've considered to find another flag matching this type of mob and it's intended behaviour, like `"HOSTILE_SEEN"`, but decided to leave it as a suggestion in this description.

#### Testing

I reproduced the bug using the debugging panel and spawning before and after making changes in the file.

#### Additional context

